### PR TITLE
Handle count in item spawn context

### DIFF
--- a/Ingame/Item/Runtime/Data/ItemSpawnContext.cs
+++ b/Ingame/Item/Runtime/Data/ItemSpawnContext.cs
@@ -15,15 +15,19 @@ namespace Ingame
         public Vector3 position;
         public ItemModel itemModel;
         public ItemID itemID => itemModel.itemID;
-        public int count => itemModel.count;
+        public int count;
         public GameObject owner;
 
-        public ItemSpawnContext(Vector3 position, ItemModel itemModel, GameObject owner = null)
+        public ItemSpawnContext(Vector3 position, ItemModel itemModel, int count, GameObject owner = null)
         {
             this.position = position;
             this.itemModel = itemModel;
+            this.count = count;
             this.owner = owner;
         }
+
+        public ItemSpawnContext(Vector3 position, ItemModel itemModel, GameObject owner = null)
+            : this(position, itemModel, itemModel.count, owner) { }
 
         public static ItemSpawnContextBuilder Builder() => new ItemSpawnContextBuilder();
     }

--- a/Ingame/Item/Runtime/Data/ItemSpawnContextBuilder.cs
+++ b/Ingame/Item/Runtime/Data/ItemSpawnContextBuilder.cs
@@ -19,11 +19,12 @@ namespace Ingame
         private int _count = 1;
         private bool _hasPosition = false;
         private bool _hasItem = false;
+        private bool _hasCount = false;
 
         public ItemSpawnContextBuilder SetCount(int count)
         {
             _count = count;
-            _hasPosition = true;
+            _hasCount = true;
             return this;
         }
 
@@ -54,7 +55,12 @@ namespace Ingame
             if (!_hasItem)
                 throw new System.InvalidOperationException("DropItemSpawnContextBuilder: itemID is required.");
 
-            return new ItemSpawnContext(_position, _itemModel, _owner);
+            if (_hasCount)
+                _itemModel.count = _count;
+            else
+                _count = _itemModel.count;
+
+            return new ItemSpawnContext(_position, _itemModel, _count, _owner);
         }
     }
 }

--- a/Ingame/Item/Runtime/ItemSystem.cs
+++ b/Ingame/Item/Runtime/ItemSystem.cs
@@ -25,7 +25,7 @@ namespace Ingame
             GameObject prefab = ItemDB.GetItemPrefab(context.itemID);
             WorldItemScope prefabScope = prefab.GetComponent<WorldItemScope>();
             {
-                prefabScope.onCreateModel = () => ItemModelFactory.Create(context.itemID, context.count);
+                prefabScope.onCreateModel = () => ItemModelFactory.Create(context.itemModel);
                 prefabScope.worldItemType = WorldItemType.HeldItem;
             }
 
@@ -61,7 +61,7 @@ namespace Ingame
             GameObject prefab = ItemDB.GetItemPrefab(context.itemID);
             WorldItemScope prefabScope = prefab.GetComponent<WorldItemScope>();
             {
-                prefabScope.onCreateModel = () => ItemModelFactory.Create(context.itemID, context.count);
+                prefabScope.onCreateModel = () => ItemModelFactory.Create(context.itemModel);
                 prefabScope.worldItemType = WorldItemType.DropItem;
             }
 


### PR DESCRIPTION
## Summary
- Add explicit `count` to `ItemSpawnContext`
- Fix `ItemSpawnContextBuilder` to apply `count`
- Use provided model when spawning items so count is respected

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f1a7099cc8330925db72a17e77eab